### PR TITLE
Fix composer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install add this line to your composer.json
 
 or
 
-```composer require clegginabox/pdf-merger: "dev-master"```
+```composer require clegginabox/pdf-merger:dev-master```
 
 ### Example Usage
 ```php


### PR DESCRIPTION
`dev-master` will be treated as a different package instead of a version when you use a space between them.