### PR TITLE
Add auto-detection of PDF page orientation.

### DIFF
--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -59,7 +59,7 @@ class PDFMerger
      * @param $orientation
      * @return PDF
      */
-    public function merge($outputmode = 'browser', $outputpath = 'newfile.pdf', $orientation = 'P')
+    public function merge($outputmode = 'browser', $outputpath = 'newfile.pdf', $orientation = 'A')
     {
         if (!isset($this->_files) || !is_array($this->_files)) {
             throw new Exception("No PDFs to merge.");
@@ -80,7 +80,9 @@ class PDFMerger
                 for ($i=1; $i<=$count; $i++) {
                     $template   = $fpdi->importPage($i);
                     $size       = $fpdi->getTemplateSize($template);
-
+                    if($fileorientation == 'A') {
+                        $fileorientation = ($size['width'] > $size['height']) ? 'L' : 'P';
+                    }
                     $fpdi->AddPage($fileorientation, array($size['width'], $size['height']));
                     $fpdi->useTemplate($template);
                 }

--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -80,7 +80,7 @@ class PDFMerger
                 for ($i=1; $i<=$count; $i++) {
                     $template   = $fpdi->importPage($i);
                     $size       = $fpdi->getTemplateSize($template);
-                    if($fileorientation == 'A') {
+                    if ($fileorientation === 'A') {
                         $fileorientation = ($size['width'] > $size['height']) ? 'L' : 'P';
                     }
                     $fpdi->AddPage($fileorientation, array($size['width'], $size['height']));


### PR DESCRIPTION
PDFMerger will use page height/width to determine orientation instead of defaulting to Portrait if nothing is specified.

The addPDF() and merge() function will now accept either 'P' (Portrait), 'L' (Landscape), or 'A' (Auto) as orientation options, with 'A' being the default.