### PR TITLE
Improved handling of page orientation in PDFMerger

### DIFF
--- a/src/PDFMerger/PDFMerger.php
+++ b/src/PDFMerger/PDFMerger.php
@@ -80,10 +80,12 @@ class PDFMerger
                 for ($i=1; $i<=$count; $i++) {
                     $template   = $fpdi->importPage($i);
                     $size       = $fpdi->getTemplateSize($template);
-                    if ($fileorientation === 'A') {
-                        $fileorientation = ($size['width'] > $size['height']) ? 'L' : 'P';
+                    $pageOrientation = ($size['width'] > $size['height']) ? 'L' : 'P';  // Determine orientation for this specific page
+
+                    if($fileorientation !== 'A') {  // If an orientation was provided for the whole document, use it
+                        $pageOrientation = $fileorientation;
                     }
-                    $fpdi->AddPage($fileorientation, array($size['width'], $size['height']));
+                    $fpdi->AddPage($pageOrientation, array($size['width'], $size['height']));
                     $fpdi->useTemplate($template);
                 }
             } else {
@@ -92,8 +94,12 @@ class PDFMerger
                         throw new Exception("Could not load page '$page' in PDF '$filename'. Check that the page exists.");
                     }
                     $size = $fpdi->getTemplateSize($template);
+                    $pageOrientation = ($size['width'] > $size['height']) ? 'L' : 'P';  // Determine orientation for this specific page
+                    if($fileorientation !== 'A') {  // If an orientation was provided for the whole document, use it
+                        $pageOrientation = $fileorientation;
+                    }
 
-                    $fpdi->AddPage($fileorientation, array($size['width'], $size['height']));
+                    $fpdi->AddPage($pageOrientation, array($size['width'], $size['height']));
                     $fpdi->useTemplate($template);
                 }
             }


### PR DESCRIPTION
In this pull request, I've addressed an issue within the `PDFMerger` class concerning the management of page orientations. Previously, when merging PDF files containing mixed page orientations (portrait and landscape) within them, the merged output did not always maintain the original orientations of the individual pages. This was due to the class converting each file to a singular orientation throughout before merging. If a file had varied page orientations internally, it was transformed to have a consistent, singular orientation.
With the modifications I've introduced, the conversion now happens on a page-by-page basis. This ensures that the original format of each file is wholly retained in the merged output.
I believe this adjustment will enhance the accuracy and integrity of the merged documents, preserving the original layout and design intended by the user.
